### PR TITLE
Add `filter` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,17 @@
 'use strict';
 const AggregateError = require('aggregate-error');
 
-module.exports = (iterable, count) => new Promise((resolve, reject) => {
-	if (!Number.isFinite(count)) {
-		throw new TypeError(`Expected a finite number, got ${typeof count}`);
+module.exports = (iterable, opts) => new Promise((resolve, reject) => {
+	opts = Object.assign({}, opts);
+
+	if (!Number.isFinite(opts.count)) {
+		throw new TypeError(`Expected a finite number, got ${typeof opts.count}`);
 	}
 
 	const values = [];
 	const errors = [];
 	let elCount = 0;
-	let maxErrors = -count + 1;
+	let maxErrors = -opts.count + 1;
 	let done = false;
 
 	const fulfilled = value => {
@@ -17,9 +19,13 @@ module.exports = (iterable, count) => new Promise((resolve, reject) => {
 			return;
 		}
 
+		if (typeof opts.filter === 'function' && !opts.filter(value)) {
+			return;
+		}
+
 		values.push(value);
 
-		if (--count === 0) {
+		if (--opts.count === 0) {
 			done = true;
 			resolve(values);
 		}
@@ -44,8 +50,8 @@ module.exports = (iterable, count) => new Promise((resolve, reject) => {
 		Promise.resolve(el).then(fulfilled, rejected);
 	}
 
-	if (count > elCount) {
-		throw new RangeError(`Expected input to contain at least ${count} items, but contains ${elCount} items`);
+	if (opts.count > elCount) {
+		throw new RangeError(`Expected input to contain at least ${opts.count} items, but contains ${elCount} items`);
 	}
 });
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = (iterable, opts) => new Promise((resolve, reject) => {
 	const errors = [];
 	let elCount = 0;
 	let maxErrors = -opts.count + 1;
+	let maxFiltered = -opts.count + 1;
 	let done = false;
 
 	const fulfilled = value => {
@@ -20,6 +21,11 @@ module.exports = (iterable, opts) => new Promise((resolve, reject) => {
 		}
 
 		if (typeof opts.filter === 'function' && !opts.filter(value)) {
+			if (--maxFiltered === 0) {
+				done = true;
+				reject(new RangeError(`Not enough values pass the \`filter\` option`));
+			}
+
 			return;
 		}
 
@@ -46,6 +52,7 @@ module.exports = (iterable, opts) => new Promise((resolve, reject) => {
 
 	for (const el of iterable) {
 		maxErrors++;
+		maxFiltered++;
 		elCount++;
 		Promise.resolve(el).then(fulfilled, rejected);
 	}

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ pSome([
 
 ## API
 
-### pSome(input, count)
+### pSome(input, options)
 
 Returns a `Promise` that is fulfilled when `count` promises from `input` are fulfilled. The fulfilled value is an `Array` of the values from the `input` promises in the order they were fulfilled. If it becomes impossible to satisfy `count`, for example, too many promises rejected, it will reject with an [`AggregateError`](https://github.com/sindresorhus/aggregate-error) error.
 
@@ -42,9 +42,20 @@ Returns a `Promise` that is fulfilled when `count` promises from `input` are ful
 
 Type: `Iterable<Promise|any>`
 
-#### count
+#### options
 
+Type: `Object`
+
+##### count
+
+*Required*<br>
 Type: `number` *(minimum `1`)*
+
+##### filter
+
+Type: `Function`
+
+Receives the value resolved by the promise. Used to filter out values that doesn't satisfy a condition.
 
 ### pSome.AggregateError
 

--- a/test.js
+++ b/test.js
@@ -84,7 +84,7 @@ test('returns an array of values #2', async t => {
 	t.deepEqual(await m(f(), {count: 3}), [1, 2, 4]);
 });
 
-test('only returns values that passes filter function', async t => {
+test('only returns values that passes `filter` option', async t => {
 	const f = [
 		'foo',
 		Promise.resolve(1),
@@ -93,4 +93,15 @@ test('only returns values that passes filter function', async t => {
 	];
 	t.deepEqual(await m(f, {count: 1, filter: val => typeof val === 'number'}), [1]);
 	t.deepEqual(await m(f, {count: 2, filter: val => typeof val === 'number'}), [1, 2]);
+});
+
+test('reject with RangeError when values returned from `filter` option doesn\'t match `count`', async t => {
+	const f = [
+		'foo',
+		Promise.resolve(1),
+		Promise.resolve('foo'),
+		2
+	];
+	const err = await t.throws(m(f, {count: 3, filter: val => typeof val === 'number'}), RangeError);
+	t.is(err.message, 'Not enough values pass the `filter` option');
 });

--- a/test.js
+++ b/test.js
@@ -3,16 +3,16 @@ import delay from 'delay';
 import m from './';
 
 test('reject with RangeError when fulfillment is impossible', async t => {
-	await t.throws(m([], 1), RangeError);
-	await t.throws(m([1, 2, 3], 4), RangeError);
-	await t.notThrows(m([1, 2, 3], 3));
-	await t.notThrows(m([1, 2, 3], 1));
+	await t.throws(m([], {count: 1}), RangeError);
+	await t.throws(m([1, 2, 3], {count: 4}), RangeError);
+	await t.notThrows(m([1, 2, 3], {count: 3}));
+	await t.notThrows(m([1, 2, 3], {count: 1}));
 });
 
 test('works with values', async t => {
-	t.deepEqual(await m([1, 2, 3], 1), [1]);
-	t.deepEqual(await m([1, 2, 3], 2), [1, 2]);
-	t.deepEqual(await m([1, 2, 3], 3), [1, 2, 3]);
+	t.deepEqual(await m([1, 2, 3], {count: 1}), [1]);
+	t.deepEqual(await m([1, 2, 3], {count: 2}), [1, 2]);
+	t.deepEqual(await m([1, 2, 3], {count: 3}), [1, 2, 3]);
 });
 
 test('works with promises', async t => {
@@ -21,9 +21,9 @@ test('works with promises', async t => {
 		Promise.resolve(2),
 		Promise.resolve(3)
 	];
-	t.deepEqual(await m(f(), 1), [1]);
-	t.deepEqual(await m(f(), 2), [1, 2]);
-	t.deepEqual(await m(f(), 3), [1, 2, 3]);
+	t.deepEqual(await m(f(), {count: 1}), [1]);
+	t.deepEqual(await m(f(), {count: 2}), [1, 2]);
+	t.deepEqual(await m(f(), {count: 3}), [1, 2, 3]);
 });
 
 test('returns values in the order they resolved', async t => {
@@ -32,7 +32,7 @@ test('returns values in the order they resolved', async t => {
 		Promise.resolve(2),
 		Promise.resolve(3).then(delay(50))
 	];
-	t.deepEqual(await m(f, 3), [2, 3, 1]);
+	t.deepEqual(await m(f, {count: 3}), [2, 3, 1]);
 });
 
 test('rejects with all errors if satisfying `count` becomes impossible', async t => {
@@ -42,7 +42,7 @@ test('rejects with all errors if satisfying `count` becomes impossible', async t
 		Promise.reject(new Error('bar')),
 		Promise.resolve(2)
 	];
-	const err = await t.throws(m(f, 3), m.AggregateError);
+	const err = await t.throws(m(f, {count: 3}), m.AggregateError);
 	const items = Array.from(err);
 	t.is(items.length, 2);
 	t.deepEqual(items, [new Error('foo'), new Error('bar')]);
@@ -55,7 +55,7 @@ test('rejects with all errors if satisfying `count` becomes impossible #2', asyn
 		Promise.reject(new Error('bar')),
 		Promise.resolve(2)
 	];
-	const err = await t.throws(m(f, 4), m.AggregateError);
+	const err = await t.throws(m(f, {count: 4}), m.AggregateError);
 	const items = Array.from(err);
 	t.is(items.length, 1);
 	t.deepEqual(items, [new Error('foo')]);
@@ -68,7 +68,7 @@ test('returns an array of values', async t => {
 		Promise.reject(new Error(3)),
 		Promise.resolve(4)
 	];
-	t.deepEqual(await m(f, 2), [2, 4]);
+	t.deepEqual(await m(f, {count: 2}), [2, 4]);
 });
 
 test('returns an array of values #2', async t => {
@@ -79,7 +79,18 @@ test('returns an array of values #2', async t => {
 		Promise.resolve(4),
 		Promise.reject(new Error(5))
 	];
-	t.deepEqual(await m(f(), 1), [1]);
-	t.deepEqual(await m(f(), 2), [1, 2]);
-	t.deepEqual(await m(f(), 3), [1, 2, 4]);
+	t.deepEqual(await m(f(), {count: 1}), [1]);
+	t.deepEqual(await m(f(), {count: 2}), [1, 2]);
+	t.deepEqual(await m(f(), {count: 3}), [1, 2, 4]);
+});
+
+test('only returns values that passes filter function', async t => {
+	const f = [
+		'foo',
+		Promise.resolve(1),
+		Promise.resolve('foo'),
+		2
+	];
+	t.deepEqual(await m(f, {count: 1, filter: val => typeof val === 'number'}), [1]);
+	t.deepEqual(await m(f, {count: 2, filter: val => typeof val === 'number'}), [1, 2]);
 });


### PR DESCRIPTION
This doesn't take `count` into account fully. E.g, if you have `{count: 3}`, and three promises resolves, but not all of them passes the `filter` function. Should we reject then?

This also moves `count` into `options` so this is a breaking change.

Fixes #1.