### PR TITLE
Fix the promise not fulfilling if the count is unachievable

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,29 +2,37 @@
 const AggregateError = require('aggregate-error');
 const PCancelable = require('p-cancelable');
 
-const pSome = (iterable, options) => new PCancelable((resolve, reject, onCancel) => {
-	options = {
-		filter: () => true,
-		...options
-	};
+class FilterError extends Error { }
 
-	if (!Number.isFinite(options.count)) {
-		throw new TypeError(`Expected a finite number, got ${typeof options.count}`);
+const pSome = (iterable, options) => new PCancelable((resolve, reject, onCancel) => {
+	const {count, filter = () => true} = options;
+
+	if (!Number.isFinite(count)) {
+		reject(new TypeError(`Expected a finite number, got ${typeof options.count}`));
+		return;
 	}
 
 	const values = [];
 	const errors = [];
 	let elementCount = 0;
-	let maxErrors = -options.count + 1;
-	let maxFiltered = -options.count + 1;
-	let isDone = false;
+	let isSettled = false;
 
 	const completed = new Set();
-	const cancelPendingIfDone = () => {
-		if (!isDone) {
-			return;
+	const maybeSettle = () => {
+		if (values.length === count) {
+			resolve(values);
+			isSettled = true;
 		}
 
+		if (elementCount - errors.length < count) {
+			reject(new AggregateError(errors));
+			isSettled = true;
+		}
+
+		return isSettled;
+	};
+
+	const cancelPending = () => {
 		for (const promise of iterable) {
 			if (!completed.has(promise) && typeof promise.cancel === 'function') {
 				promise.cancel();
@@ -32,66 +40,36 @@ const pSome = (iterable, options) => new PCancelable((resolve, reject, onCancel)
 		}
 	};
 
-	onCancel(() => {
-		isDone = true;
-		cancelPendingIfDone();
-	});
-
-	const fulfilled = value => {
-		if (isDone) {
-			return;
-		}
-
-		if (!options.filter(value)) {
-			if (--maxFiltered === 0) {
-				isDone = true;
-				reject(new RangeError('Not enough values pass the `filter` option'));
-			}
-
-			return;
-		}
-
-		values.push(value);
-
-		if (--options.count === 0) {
-			isDone = true;
-			resolve(values);
-		}
-	};
-
-	const rejected = error => {
-		if (isDone) {
-			return;
-		}
-
-		errors.push(error);
-
-		if (--maxErrors === 0) {
-			isDone = true;
-			reject(new AggregateError(errors));
-		}
-	};
+	onCancel(cancelPending);
 
 	for (const element of iterable) {
-		maxErrors++;
-		maxFiltered++;
 		elementCount++;
-
 		(async () => {
 			try {
-				const value = await Promise.resolve(element);
-				fulfilled(value);
-			} catch (error) {
-				rejected(error);
-			}
+				const value = await element;
+				if (isSettled) {
+					return;
+				}
 
-			completed.add(element);
-			cancelPendingIfDone();
+				if (!filter(value)) {
+					throw new FilterError('Value does not satisfy filter');
+				}
+
+				values.push(value);
+			} catch (error) {
+				errors.push(error);
+			} finally {
+				completed.add(element);
+				if (!isSettled && maybeSettle()) {
+					cancelPending();
+				}
+			}
 		})();
 	}
 
-	if (options.count > elementCount) {
-		throw new RangeError(`Expected input to contain at least ${options.count} items, but contains ${elementCount} items`);
+	if (count > elementCount) {
+		reject(new RangeError(`Expected input to contain at least ${options.count} items, but contains ${elementCount} items`));
+		cancelPending();
 	}
 });
 
@@ -100,3 +78,4 @@ module.exports = pSome;
 module.exports.default = pSome;
 
 module.exports.AggregateError = AggregateError;
+module.exports.FilterError = FilterError;


### PR DESCRIPTION
Throwing an error when a value is filtered simplifies identifying when
the operation has reached a terminal state and should result in a
rejection.

Another option would be to just remove the `filter` option, since the same thing can be accomplished by the user:
```js
psome([1, 2, 3]
	.map(p => Promise.resolve(p))
	.map(p => p.then(v => {
		if (v < 2) {
			throw new Error('too low');
		}
	})))
```