### PR TITLE
feat: able to use in non-node environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,8 @@ module.exports = (iterable, options) => new PCancelable((resolve, reject, onCanc
 
 		if (--maxErrors === 0) {
 			done = true;
-			reject(new AggregateError(errors));
+			const isNode = typeof process !== 'undefined' && process.versions != null && process.versions.node != null;
+			reject(isNode ? new AggregateError(errors) : new Error(errors));
 		}
 	};
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = (iterable, options) => new PCancelable((resolve, reject, onCanc
 		if (typeof options.filter === 'function' && !options.filter(value)) {
 			if (--maxFiltered === 0) {
 				done = true;
-				reject(new RangeError(`Not enough values pass the \`filter\` option`));
+				reject(new RangeError('Not enough values pass the `filter` option'));
 			}
 
 			return;
@@ -65,7 +65,7 @@ module.exports = (iterable, options) => new PCancelable((resolve, reject, onCanc
 
 		if (--maxErrors === 0) {
 			done = true;
-			const isNode = typeof process !== 'undefined' && process.versions != null && process.versions.node != null;
+			const isNode = typeof process !== 'undefined' && process.versions !== null && process.versions.node !== null;
 			reject(isNode ? new AggregateError(errors) : new Error(errors));
 		}
 	};


### PR DESCRIPTION
The library is awesome, but it's not usable in non-node environment due to the dependencies of `aggregate-error` which require `clean-stack` and require `os` node's module.

Hopefully we can use this in different targets